### PR TITLE
Fix ClausesBuilder import on test file

### DIFF
--- a/test/Storage.test.ts
+++ b/test/Storage.test.ts
@@ -1,5 +1,5 @@
 import {ethers} from "hardhat";
-import {ClausesBuilder} from "../../hardhat-plugins/packages/vechain/dist/clausesBuilder";
+import {ClausesBuilder} from "@vechain/hardhat-vechain/dist/clausesBuilder";
 
 const { expect } = require("chai");
 


### PR DESCRIPTION
The `ClausesBuilder` import is currently broken at `test/Storage.test.ts` and test are not running.

This PR fixes the import mentioned above.